### PR TITLE
Add support for increase the expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ $token->update([
 ]);
 ```
 
+Or just use the class's helper methods.
+
+```php
+$token = Bearer::find('my-token-string');
+
+$token->addWeeks(1)->save();
+```
+
 If you try to use the token after this time, it will return an error.
 
 ### Limit tokens to a particular domain

--- a/src/Concerns/InteractsWithExpiration.php
+++ b/src/Concerns/InteractsWithExpiration.php
@@ -6,9 +6,6 @@ use RyanChandler\Bearer\Models\Token;
 
 trait InteractsWithExpiration
 {
-    /**
-     * Add months to the expiration date.
-     */
     public function addMonths(int $months): Token
     {
         $expires = $this->expires_at ?: now();
@@ -16,9 +13,6 @@ trait InteractsWithExpiration
         return $this->expires($expires->addMonths($months));
     }
 
-    /**
-     * Add weeks to the expiration date.
-     */
     public function addWeeks(int $weeks): Token
     {
         $expires = $this->expires_at ?: now();
@@ -26,9 +20,6 @@ trait InteractsWithExpiration
         return $this->expires($expires->addWeeks($weeks));
     }
 
-    /**
-     * Add days to the expiration date.
-     */
     public function addDays(int $days): Token
     {
         $expires = $this->expires_at ?: now();
@@ -36,9 +27,6 @@ trait InteractsWithExpiration
         return $this->expires($expires->addDays($days));
     }
 
-    /**
-     * Add hours to the expiration date.
-     */
     public function addHours(int $hours): Token
     {
         $expires = $this->expires_at ?: now();
@@ -46,9 +34,6 @@ trait InteractsWithExpiration
         return $this->expires($expires->addHours($hours));
     }
 
-    /**
-     * Add minutes to the expiration date.
-     */
     public function addMinutes(int $minutes): Token
     {
         $expires = $this->expires_at ?: now();

--- a/src/Concerns/InteractsWithExpiration.php
+++ b/src/Concerns/InteractsWithExpiration.php
@@ -2,37 +2,54 @@
 
 namespace RyanChandler\Bearer\Concerns;
 
+use RyanChandler\Bearer\Models\Token;
+
 trait InteractsWithExpiration
 {
-    public function addMonths(int $months)
+    /**
+     * Add months to the expiration date.
+     */
+    public function addMonths(int $months): Token
     {
         $expires = $this->expires_at ?: now();
 
         return $this->expires($expires->addMonths($months));
     }
 
-    public function addWeeks(int $weeks)
+    /**
+     * Add weeks to the expiration date.
+     */
+    public function addWeeks(int $weeks): Token
     {
         $expires = $this->expires_at ?: now();
 
         return $this->expires($expires->addWeeks($weeks));
     }
 
-    public function addDays(int $days)
+    /**
+     * Add days to the expiration date.
+     */
+    public function addDays(int $days): Token
     {
         $expires = $this->expires_at ?: now();
 
         return $this->expires($expires->addDays($days));
     }
 
-    public function addHours(int $hours)
+    /**
+     * Add hours to the expiration date.
+     */
+    public function addHours(int $hours): Token
     {
         $expires = $this->expires_at ?: now();
 
         return $this->expires($expires->addHours($hours));
     }
 
-    public function addMinutes(int $minutes)
+    /**
+     * Add minutes to the expiration date.
+     */
+    public function addMinutes(int $minutes): Token
     {
         $expires = $this->expires_at ?: now();
 

--- a/src/Concerns/InteractsWithExpiration.php
+++ b/src/Concerns/InteractsWithExpiration.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace RyanChandler\Bearer\Concerns;
+
+trait InteractsWithExpiration
+{
+    public function addMonths(int $months)
+    {
+        $expires = $this->expires_at ?: now();
+
+        return $this->expires($expires->addMonths($months));
+    }
+
+    public function addWeeks(int $weeks)
+    {
+        $expires = $this->expires_at ?: now();
+
+        return $this->expires($expires->addWeeks($weeks));
+    }
+
+    public function addDays(int $days)
+    {
+        $expires = $this->expires_at ?: now();
+
+        return $this->expires($expires->addDays($days));
+    }
+
+    public function addHours(int $hours)
+    {
+        $expires = $this->expires_at ?: now();
+
+        return $this->expires($expires->addHours($hours));
+    }
+
+    public function addMinutes(int $minutes)
+    {
+        $expires = $this->expires_at ?: now();
+
+        return $this->expires($expires->addMinutes($minutes));
+    }
+}

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -49,7 +49,7 @@ class Token extends Model
         return $this;
     }
 
-    public function expires(DateTimeInterface $expiresAt)
+    public function expires(DateTimeInterface $expiresAt): Token
     {
         $this->expires_at = $expiresAt;
 

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -2,13 +2,16 @@
 
 namespace RyanChandler\Bearer\Models;
 
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use RyanChandler\Bearer\Concerns\InteractsWithExpiration;
 
 class Token extends Model
 {
     use HasFactory;
+    use InteractsWithExpiration;
 
     protected $table = 'bearer_tokens';
 
@@ -42,6 +45,13 @@ class Token extends Model
         }
 
         $this->domains[] = $domain;
+
+        return $this;
+    }
+
+    public function expires(DateTimeInterface $expiresAt)
+    {
+        $this->expires_at = $expiresAt;
 
         return $this;
     }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -61,10 +61,9 @@ class TokenTest extends TestCase
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
-        Carbon::withTestNow(
-            now()->addMonths($minutes + 1),
-            fn () => $this->assertTrue($token->expired)
-        );
+        Carbon::setTestNow(now()->addMinutes($minutes + 1));
+        $this->assertTrue($token->expired);
+        Carbon::setTestNow();
     }
 
     public function test_it_can_interacts_with_expiration_time_in_hours()
@@ -75,10 +74,9 @@ class TokenTest extends TestCase
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
-        Carbon::withTestNow(
-            now()->addMonths($hours + 1),
-            fn () => $this->assertTrue($token->expired)
-        );
+        Carbon::setTestNow(now()->addHours($hours + 1));
+        $this->assertTrue($token->expired);
+        Carbon::setTestNow();
     }
 
     public function test_it_can_interacts_with_expiration_time_in_days()
@@ -89,10 +87,9 @@ class TokenTest extends TestCase
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
-        Carbon::withTestNow(
-            now()->addMonths($days + 1),
-            fn () => $this->assertTrue($token->expired)
-        );
+        Carbon::setTestNow(now()->addDays($days + 1));
+        $this->assertTrue($token->expired);
+        Carbon::setTestNow();
     }
 
     public function test_it_can_interacts_with_expiration_time_in_weeks()
@@ -103,10 +100,9 @@ class TokenTest extends TestCase
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
-        Carbon::withTestNow(
-            now()->addMonths($weeks + 1),
-            fn () => $this->assertTrue($token->expired)
-        );
+        Carbon::setTestNow(now()->addWeeks($weeks + 1));
+        $this->assertTrue($token->expired);
+        Carbon::setTestNow();
     }
 
     public function test_it_can_interacts_with_expiration_time_in_months()
@@ -117,9 +113,8 @@ class TokenTest extends TestCase
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
-        Carbon::withTestNow(
-            now()->addMonths($months + 1),
-            fn () => $this->assertTrue($token->expired)
-        );
+        Carbon::setTestNow(now()->addMonths($months + 1));
+        $this->assertTrue($token->expired);
+        Carbon::setTestNow();
     }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -3,6 +3,7 @@
 namespace RyanChandler\Bearer\Tests;
 
 use RyanChandler\Bearer\Models\Token;
+use Illuminate\Support\Carbon;
 
 class TokenTest extends TestCase
 {
@@ -50,5 +51,75 @@ class TokenTest extends TestCase
             ->create();
 
         $this->assertTrue($token->expired);
+    }
+
+    public function test_it_can_interacts_with_expiration_time_in_minutes()
+    {
+        $token = Token::factory()->expired()->create();
+
+        $token->addMinutes($minutes = rand(1, 7));
+        $this->assertFalse($token->expired);
+        $this->assertTrue($token->expires_at->isFuture());
+
+        Carbon::withTestNow(
+            now()->addMonths($minutes + 1),
+            fn () => $this->assertTrue($token->expired)
+        );
+    }
+
+    public function test_it_can_interacts_with_expiration_time_in_hours()
+    {
+        $token = Token::factory()->expired()->create();
+
+        $token->addHours($hours = rand(1, 7));
+        $this->assertFalse($token->expired);
+        $this->assertTrue($token->expires_at->isFuture());
+
+        Carbon::withTestNow(
+            now()->addMonths($hours + 1),
+            fn () => $this->assertTrue($token->expired)
+        );
+    }
+
+    public function test_it_can_interacts_with_expiration_time_in_days()
+    {
+        $token = Token::factory()->expired()->create();
+
+        $token->addDays($days = rand(1, 7));
+        $this->assertFalse($token->expired);
+        $this->assertTrue($token->expires_at->isFuture());
+
+        Carbon::withTestNow(
+            now()->addMonths($days + 1),
+            fn () => $this->assertTrue($token->expired)
+        );
+    }
+
+    public function test_it_can_interacts_with_expiration_time_in_weeks()
+    {
+        $token = Token::factory()->expired()->create();
+
+        $token->addWeeks($weeks = rand(1, 7));
+        $this->assertFalse($token->expired);
+        $this->assertTrue($token->expires_at->isFuture());
+
+        Carbon::withTestNow(
+            now()->addMonths($weeks + 1),
+            fn () => $this->assertTrue($token->expired)
+        );
+    }
+
+    public function test_it_can_interacts_with_expiration_time_in_months()
+    {
+        $token = Token::factory()->expired()->create();
+
+        $token->addMonths($months = rand(1, 7));
+        $this->assertFalse($token->expired);
+        $this->assertTrue($token->expires_at->isFuture());
+
+        Carbon::withTestNow(
+            now()->addMonths($months + 1),
+            fn () => $this->assertTrue($token->expired)
+        );
     }
 }

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -57,7 +57,7 @@ class TokenTest extends TestCase
     {
         $token = Token::factory()->expired()->create();
 
-        $token->addMinutes($minutes = rand(1, 7));
+        $token->addMinutes($minutes = rand(1, 5));
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
@@ -70,7 +70,7 @@ class TokenTest extends TestCase
     {
         $token = Token::factory()->expired()->create();
 
-        $token->addHours($hours = rand(1, 7));
+        $token->addHours($hours = rand(1, 5));
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
@@ -83,7 +83,7 @@ class TokenTest extends TestCase
     {
         $token = Token::factory()->expired()->create();
 
-        $token->addDays($days = rand(1, 7));
+        $token->addDays($days = rand(1, 5));
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
@@ -96,7 +96,7 @@ class TokenTest extends TestCase
     {
         $token = Token::factory()->expired()->create();
 
-        $token->addWeeks($weeks = rand(1, 7));
+        $token->addWeeks($weeks = rand(1, 5));
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 
@@ -109,7 +109,7 @@ class TokenTest extends TestCase
     {
         $token = Token::factory()->expired()->create();
 
-        $token->addMonths($months = rand(1, 7));
+        $token->addMonths($months = rand(1, 5));
         $this->assertFalse($token->expired);
         $this->assertTrue($token->expires_at->isFuture());
 


### PR DESCRIPTION
This PR add a couple of methods to interact with the expiration date of the token based on the `Carbon\Carbon` api. E.G,

```php
<?php

use RyanChandler\Bearer\Facades\Bearer;

$token = Bearer::generate(domains: ['https://google.com'], expiresAt: now()->subMinutes(2));

$token->expired; // true

$token->addDays(2);

$token->expired; // false

$token->save();
```

Methods added:
```php
<?php

$token->addMinutes(int $minutes);

$token->addHours(int $hours);

$token->addDays(int $days);

$token->addWeeks(int $weeks);

$token->addMonths(int $months);
```

I hope it is useful.